### PR TITLE
NET 10

### DIFF
--- a/HeroesPowerPlant.RemoteControl.TestApp/HeroesPowerPlant.RemoteControl.TestApp.csproj
+++ b/HeroesPowerPlant.RemoteControl.TestApp/HeroesPowerPlant.RemoteControl.TestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/HeroesPowerPlant.RemoteControl/HeroesPowerPlant.RemoteControl.csproj
+++ b/HeroesPowerPlant.RemoteControl/HeroesPowerPlant.RemoteControl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>


### PR DESCRIPTION
* New Heroes.SDK
* Compile as NET 10 target


Tested with experimental NET 10 Reloaded-II build with latest NET 10 Heroes Power Plant.
With the netcoreapp3.1 version it never connects to NET 10 HPP for some reason.